### PR TITLE
Make PROMPT_VERSION optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ A collection of Python CLI tools for processing artist data with OpenAI's Batch 
 
 - Python 3.11+
 - For `gen_batch_jsonl.py`: No external dependencies (uses standard library only)
-- For `batch_tool.py`: OpenAI Python SDK (`pip install openai`)
+- For `batch_tool.py`: 
+  - OpenAI Python SDK (`pip install openai`)
+  - OpenAI API key (set via `OPENAI_API_KEY` environment variable)
 
 ## Installation
 
@@ -53,7 +55,11 @@ Converts CSV files of artist data into OpenAI Batch API JSONL format.
 ## Basic Usage
 
 ```bash
+# With prompt version
 python gen_batch_jsonl.py --in input.csv --out output.jsonl --prompt-id bio_gen --prompt-version v1.0
+
+# Without prompt version (version field omitted from JSON)
+python gen_batch_jsonl.py --in input.csv --out output.jsonl --prompt-id bio_gen
 ```
 
 ## Configuration Options
@@ -102,6 +108,7 @@ Known for 'love the world'"
 
 Each line in the output file will be a JSON object formatted for the OpenAI Batch API:
 
+**With prompt version:**
 ```json
 {
   "custom_id": "a1",
@@ -120,6 +127,24 @@ Each line in the output file will be a JSON object formatted for the OpenAI Batc
 }
 ```
 
+**Without prompt version (when `--prompt-version` is omitted):**
+```json
+{
+  "custom_id": "a1",
+  "method": "POST", 
+  "url": "/v1/responses",
+  "body": {
+    "prompt": {
+      "id": "bio_gen",
+      "variables": {
+        "artist_name": "NewJeans",
+        "artist_data": "K-pop group; ADOR; 'Supernatural' era"
+      }
+    }
+  }
+}
+```
+
 ## Configuration
 
 Configuration can be provided via CLI flags (higher priority) or environment variables:
@@ -127,7 +152,7 @@ Configuration can be provided via CLI flags (higher priority) or environment var
 | CLI Flag | Environment Variable | Description | Required |
 |----------|---------------------|-------------|----------|
 | `--prompt-id` | `PROMPT_ID` | Prompt identifier | Yes |
-| `--prompt-version` | `PROMPT_VERSION` | Prompt version | Yes |
+| `--prompt-version` | `PROMPT_VERSION` | Prompt version | No (optional) |
 
 ## Error Handling
 
@@ -289,7 +314,7 @@ Each line is a JSON object for the OpenAI Batch API:
 | Tool | CLI Flag | Environment Variable | Description | Required |
 |------|----------|---------------------|-------------|----------|
 | `gen_batch_jsonl.py` | `--prompt-id` | `PROMPT_ID` | Prompt identifier | Yes |
-| `gen_batch_jsonl.py` | `--prompt-version` | `PROMPT_VERSION` | Prompt version | Yes |
+| `gen_batch_jsonl.py` | `--prompt-version` | `PROMPT_VERSION` | Prompt version | No (optional) |
 | `batch_tool.py` | N/A | `OPENAI_API_KEY` | OpenAI API key | Yes |
 
 ## Error Handling

--- a/tests/test_gen_batch_jsonl.py
+++ b/tests/test_gen_batch_jsonl.py
@@ -5,6 +5,7 @@ Tests for gen_batch_jsonl.py
 
 import io
 import json
+import os
 import unittest
 import tempfile
 from pathlib import Path
@@ -18,6 +19,8 @@ from gen_batch_jsonl import (
     convert_csv_to_jsonl,
     validate_row,
     process_csv_rows,
+    get_config_value,
+    main,
     ConversionStats
 )
 
@@ -77,6 +80,60 @@ class TestBuildTaskRow(unittest.TestCase):
         
         self.assertEqual(result["body"]["prompt"]["variables"]["artist_name"], "Björk")
         self.assertEqual(result["body"]["prompt"]["variables"]["artist_data"], "Icelandic artist with émotion")
+    
+    def test_optional_prompt_version(self):
+        """Test task row without prompt version."""
+        result = build_task_row(
+            artist_id="test_id",
+            artist_name="Test Artist",
+            artist_data="Test data",
+            prompt_id="bio_gen"
+        )
+        
+        expected = {
+            "custom_id": "test_id",
+            "method": "POST",
+            "url": "/v1/responses",
+            "body": {
+                "prompt": {
+                    "id": "bio_gen",
+                    "variables": {
+                        "artist_name": "Test Artist",
+                        "artist_data": "Test data"
+                    }
+                }
+            }
+        }
+        
+        self.assertEqual(result, expected)
+        # Ensure version key is not present
+        self.assertNotIn("version", result["body"]["prompt"])
+    
+    def test_none_prompt_version(self):
+        """Test task row with explicit None prompt version."""
+        result = build_task_row(
+            artist_id="test_id",
+            artist_name="Test Artist",
+            artist_data="Test data",
+            prompt_id="bio_gen",
+            prompt_version=None
+        )
+        
+        # Should behave same as omitted version
+        self.assertNotIn("version", result["body"]["prompt"])
+    
+    def test_empty_string_prompt_version(self):
+        """Test task row with empty string prompt version."""
+        result = build_task_row(
+            artist_id="test_id",
+            artist_name="Test Artist",
+            artist_data="Test data",
+            prompt_id="bio_gen",
+            prompt_version=""
+        )
+        
+        # Empty string should be treated as falsy, version not included
+        self.assertNotIn("version", result["body"]["prompt"])
 
 
 class TestValidateRow(unittest.TestCase):
@@ -283,6 +340,254 @@ a3,Another Valid,More valid data""")
             
             output_lines = output_path.read_text().strip().split('\n')
             self.assertEqual(len(output_lines), 2)
+
+
+class TestGetConfigValue(unittest.TestCase):
+    """Test the get_config_value function."""
+    
+    def test_cli_arg_takes_precedence(self):
+        """Test that CLI argument takes precedence over environment variable."""
+        with patch.dict(os.environ, {'TEST_VAR': 'env_value'}):
+            result = get_config_value('cli_value', 'TEST_VAR', 'test_param')
+            self.assertEqual(result, 'cli_value')
+    
+    def test_env_var_when_no_cli_arg(self):
+        """Test using environment variable when no CLI arg provided."""
+        with patch.dict(os.environ, {'TEST_VAR': 'env_value'}):
+            result = get_config_value(None, 'TEST_VAR', 'test_param')
+            self.assertEqual(result, 'env_value')
+    
+    def test_required_parameter_missing(self):
+        """Test error when required parameter is missing from both sources."""
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError) as cm:
+                get_config_value(None, 'MISSING_VAR', 'test_param')
+            
+            self.assertIn('test_param must be provided', str(cm.exception))
+            self.assertIn('--test-param', str(cm.exception))
+            self.assertIn('MISSING_VAR', str(cm.exception))
+    
+    def test_optional_parameter_returns_none(self):
+        """Test that optional parameter returns None when missing."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = get_config_value(None, 'MISSING_VAR', 'test_param', required=False)
+            self.assertIsNone(result)
+    
+    def test_optional_parameter_with_cli_arg(self):
+        """Test optional parameter with CLI argument provided."""
+        result = get_config_value('cli_value', 'MISSING_VAR', 'test_param', required=False)
+        self.assertEqual(result, 'cli_value')
+    
+    def test_optional_parameter_with_env_var(self):
+        """Test optional parameter with environment variable provided."""
+        with patch.dict(os.environ, {'TEST_VAR': 'env_value'}):
+            result = get_config_value(None, 'TEST_VAR', 'test_param', required=False)
+            self.assertEqual(result, 'env_value')
+    
+    def test_empty_string_cli_arg_required(self):
+        """Test that empty string CLI arg raises error when required."""
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                get_config_value('', 'TEST_VAR', 'test_param')
+    
+    def test_empty_string_cli_arg_optional(self):
+        """Test that empty string CLI arg returns None when optional."""
+        with patch.dict(os.environ, {}, clear=True):
+            result = get_config_value('', 'TEST_VAR', 'test_param', required=False)
+            self.assertIsNone(result)
+    
+    def test_empty_string_env_var_required(self):
+        """Test that empty string env var raises error when required."""
+        with patch.dict(os.environ, {'TEST_VAR': ''}):
+            with self.assertRaises(ValueError):
+                get_config_value(None, 'TEST_VAR', 'test_param')
+    
+    def test_empty_string_env_var_optional(self):
+        """Test that empty string env var returns None when optional."""
+        with patch.dict(os.environ, {'TEST_VAR': ''}):
+            result = get_config_value(None, 'TEST_VAR', 'test_param', required=False)
+            self.assertIsNone(result)
+
+
+class TestConvertCsvToJsonlOptionalVersion(unittest.TestCase):
+    """Test CSV to JSONL conversion with optional prompt version."""
+    
+    def test_conversion_without_prompt_version(self):
+        """Test conversion without prompt version."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "input.csv"
+            output_path = Path(tmpdir) / "output.jsonl"
+            
+            # Create test CSV
+            input_path.write_text("""artist_id,artist_name,artist_data
+a1,NewJeans,K-pop group
+a2,Stereolab,Post-rock band""")
+            
+            # Convert without version
+            stats = convert_csv_to_jsonl(
+                input_path=input_path,
+                output_path=output_path,
+                prompt_id="test_prompt",
+                prompt_version=None
+            )
+            
+            # Check stats
+            self.assertEqual(stats.read, 2)
+            self.assertEqual(stats.written, 2)
+            self.assertEqual(stats.skipped, 0)
+            
+            # Check output
+            output_lines = output_path.read_text().strip().split('\n')
+            self.assertEqual(len(output_lines), 2)
+            
+            # Parse first line and verify no version field
+            first_task = json.loads(output_lines[0])
+            self.assertEqual(first_task['custom_id'], 'a1')
+            self.assertEqual(first_task['body']['prompt']['id'], 'test_prompt')
+            self.assertNotIn('version', first_task['body']['prompt'])
+            self.assertEqual(first_task['body']['prompt']['variables']['artist_name'], 'NewJeans')
+    
+    def test_conversion_with_prompt_version(self):
+        """Test conversion with prompt version still works."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "input.csv"
+            output_path = Path(tmpdir) / "output.jsonl"
+            
+            # Create test CSV
+            input_path.write_text("""artist_id,artist_name,artist_data
+a1,Artist One,Data one""")
+            
+            # Convert with version
+            stats = convert_csv_to_jsonl(
+                input_path=input_path,
+                output_path=output_path,
+                prompt_id="test_prompt",
+                prompt_version="v1.0"
+            )
+            
+            # Check output includes version
+            output_lines = output_path.read_text().strip().split('\n')
+            first_task = json.loads(output_lines[0])
+            self.assertEqual(first_task['body']['prompt']['version'], 'v1.0')
+
+
+class TestMainFunctionOptionalVersion(unittest.TestCase):
+    """Test main function with optional PROMPT_VERSION."""
+    
+    def test_main_with_prompt_version_env_var(self):
+        """Test main function with PROMPT_VERSION environment variable."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "input.csv"
+            output_path = Path(tmpdir) / "output.jsonl"
+            
+            # Create test CSV
+            input_path.write_text("""artist_id,artist_name,artist_data
+a1,Test Artist,Test data""")
+            
+            # Mock sys.argv and environment
+            test_args = [
+                'gen_batch_jsonl.py',
+                '--in', str(input_path),
+                '--out', str(output_path),
+                '--prompt-id', 'test_prompt',
+                '--prompt-version', 'v2.0'
+            ]
+            
+            with patch('sys.argv', test_args):
+                with patch('logging.info') as mock_log:
+                    exit_code = main()
+            
+            # Check success
+            self.assertEqual(exit_code, 0)
+            
+            # Check that version was logged
+            log_calls = [call.args[0] for call in mock_log.call_args_list]
+            version_logged = any('prompt_version: v2.0' in call for call in log_calls)
+            self.assertTrue(version_logged)
+            
+            # Check output file
+            self.assertTrue(output_path.exists())
+            output_lines = output_path.read_text().strip().split('\n')
+            first_task = json.loads(output_lines[0])
+            self.assertEqual(first_task['body']['prompt']['version'], 'v2.0')
+    
+    def test_main_without_prompt_version(self):
+        """Test main function without PROMPT_VERSION."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "input.csv"
+            output_path = Path(tmpdir) / "output.jsonl"
+            
+            # Create test CSV
+            input_path.write_text("""artist_id,artist_name,artist_data
+a1,Test Artist,Test data""")
+            
+            # Mock sys.argv without version
+            test_args = [
+                'gen_batch_jsonl.py',
+                '--in', str(input_path),
+                '--out', str(output_path),
+                '--prompt-id', 'test_prompt'
+            ]
+            
+            # Ensure no PROMPT_VERSION in environment
+            with patch.dict(os.environ, {}, clear=True):
+                os.environ['PROMPT_ID'] = 'test_prompt'  # Required, so set it
+                
+                with patch('sys.argv', test_args):
+                    with patch('logging.info') as mock_log:
+                        exit_code = main()
+            
+            # Check success
+            self.assertEqual(exit_code, 0)
+            
+            # Check that "no version specified" was logged
+            log_calls = [call.args[0] for call in mock_log.call_args_list]
+            no_version_logged = any('no version specified' in call for call in log_calls)
+            self.assertTrue(no_version_logged)
+            
+            # Check output file has no version
+            self.assertTrue(output_path.exists())
+            output_lines = output_path.read_text().strip().split('\n')
+            first_task = json.loads(output_lines[0])
+            self.assertNotIn('version', first_task['body']['prompt'])
+    
+    def test_main_with_prompt_version_from_env(self):
+        """Test main function with PROMPT_VERSION from environment variable."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "input.csv"
+            output_path = Path(tmpdir) / "output.jsonl"
+            
+            # Create test CSV
+            input_path.write_text("""artist_id,artist_name,artist_data
+a1,Test Artist,Test data""")
+            
+            # Mock sys.argv without version argument
+            test_args = [
+                'gen_batch_jsonl.py',
+                '--in', str(input_path),
+                '--out', str(output_path),
+                '--prompt-id', 'test_prompt'
+            ]
+            
+            # Set version via environment variable
+            with patch.dict(os.environ, {'PROMPT_VERSION': 'v3.0'}):
+                with patch('sys.argv', test_args):
+                    with patch('logging.info') as mock_log:
+                        exit_code = main()
+            
+            # Check success
+            self.assertEqual(exit_code, 0)
+            
+            # Check that version from env was logged
+            log_calls = [call.args[0] for call in mock_log.call_args_list]
+            version_logged = any('prompt_version: v3.0' in call for call in log_calls)
+            self.assertTrue(version_logged)
+            
+            # Check output file has version
+            self.assertTrue(output_path.exists())
+            output_lines = output_path.read_text().strip().split('\n')
+            first_task = json.loads(output_lines[0])
+            self.assertEqual(first_task['body']['prompt']['version'], 'v3.0')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Modified build_task_row() to only include version field when provided
- Updated get_config_value() to support optional parameters with required=False
- Added comprehensive test coverage for optional PROMPT_VERSION behavior
- Updated README.md to clarify OPENAI_API_KEY requirement and optional PROMPT_VERSION
- Added 16 new test cases covering edge cases and integration scenarios
- All 49 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)