### PR TITLE
Add batch cancel command to batch_tool.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A collection of Python CLI tools for processing artist data with OpenAI's Batch API:
 
 1. **`gen_batch_jsonl.py`** - Converts CSV files of artist data into OpenAI Batch API JSONL format
-2. **`batch_tool.py`** - Manages OpenAI Batch API operations (create, status, retrieve)
+2. **`batch_tool.py`** - Manages OpenAI Batch API operations (create, status, retrieve, cancel)
 
 ## Requirements
 
@@ -44,6 +44,9 @@ python batch_tool.py status --batch-id batch-def456
 
 # 4. Or manually retrieve results
 python batch_tool.py retrieve --batch-id batch-def456 --out final_results.jsonl
+
+# 5. Or cancel if needed (charges apply for completed work)
+python batch_tool.py cancel --batch-id batch-def456
 ```
 
 ---
@@ -191,7 +194,7 @@ python gen_batch_jsonl.py --in samples/input.csv --out test.jsonl --prompt-id te
 
 # Tool 2: OpenAI Batch API Manager (`batch_tool.py`)
 
-Manages OpenAI Batch API operations: creating batches, checking status, and retrieving results.
+Manages OpenAI Batch API operations: creating batches, checking status, retrieving results, and cancelling jobs.
 
 ## Operations
 
@@ -252,11 +255,43 @@ python batch_tool.py retrieve --batch-id batch-def456 --out my_results.jsonl
 - `--batch-id <id>` (required): Batch ID to retrieve
 - `--out <path>` (optional): Output file path (default: `results_<batch_id>.jsonl`)
 
+### 4. Cancel Batch
+
+Cancel a batch job that is queued or in progress:
+
+```bash
+python batch_tool.py cancel --batch-id batch-def456
+```
+
+**Options:**
+- `--batch-id <id>` (required): Batch ID to cancel
+
+**Output examples:**
+```
+# Successfully cancelled
+Batch cancellation initiated: batch-def456
+Status: cancelled
+Created: 2024-01-15 10:30:00
+Note: Batch was successfully cancelled. Any completed requests have been processed and you will be charged for them.
+
+# Cancellation in progress
+Batch cancellation initiated: batch-def456
+Status: cancelling
+Created: 2024-01-15 10:30:00
+Note: Batch cancellation in progress. This may take up to 10 minutes.
+```
+
+**Important Notes:**
+- You can cancel batches that are `validating`, `queued`, `in_progress`, or `finalizing`
+- Any completed requests will be processed and you'll be charged for them
+- Cancellation may take up to 10 minutes to complete
+- Once cancelled, partial results (if any) will be available in the output file
+
 ## Logging
 
 All operations are logged to `logs/batch_YYYYMMDD_HHMMSS.log` (or use `--log-file <path>`):
 
-- All API operations (UPLOAD, CREATE_BATCH, GET_STATUS, DOWNLOAD_RESULTS)
+- All API operations (UPLOAD, CREATE_BATCH, GET_STATUS, CANCEL_BATCH, DOWNLOAD_RESULTS)
 - Request metadata (without secrets)
 - Response data (except large result files)
 - Error details and stack traces
@@ -348,7 +383,7 @@ python -m pytest tests/ -v
 ```
 
 **Test coverage:**
-- 31 total tests (16 for batch_tool.py, 15 for gen_batch_jsonl.py)
+- 56 total tests (23 for batch_tool.py, 33 for gen_batch_jsonl.py)
 - Edge cases: CSV parsing, file validation, API mocking
 - Integration tests: End-to-end workflows
 


### PR DESCRIPTION
## Summary
- Added new `cancel` command to batch_tool.py for cancelling OpenAI batch jobs
- Implemented complete CLI integration with argument parsing and command dispatch
- Added comprehensive test coverage and updated documentation

## Features Added
- **`cancel_batch()` function**: Core API integration using `client.batches.cancel()`
- **`cmd_cancel()` command handler**: User-friendly CLI interface with status messaging
- **CLI argument parser**: New `cancel` subcommand with required `--batch-id` parameter
- **Comprehensive logging**: All operations logged for debugging and audit trails

## Usage
```bash
# Cancel a batch job
python batch_tool.py cancel --batch-id batch_abc123
```

## Output Examples
```
# Successfully cancelled
Batch cancellation initiated: batch_abc123
Status: cancelled
Created: 2024-01-15 10:30:00
Note: Batch was successfully cancelled. Any completed requests have been processed and you will be charged for them.
```

## Test Coverage
- **7 new test cases** covering success/error scenarios, different status states, and CLI integration
- **All 56 tests passing** (23 batch_tool tests + 33 gen_batch_jsonl tests)
- Mock-based testing for API interactions and edge cases

## Documentation Updates
- Updated README.md with complete cancel command documentation
- Added usage examples, output samples, and important billing notes
- Updated tool descriptions and test coverage statistics

## Technical Details
- Uses OpenAI Python SDK `batches.cancel()` method
- Handles different cancellation states (`cancelled` vs `cancelling`)
- Provides clear user messaging about billing and timing expectations
- Follows existing code patterns for logging, error handling, and CLI structure

## Important Notes
- Cancellation can take up to 10 minutes to complete
- Users are charged for any completed requests before cancellation
- Works for batches in `validating`, `queued`, `in_progress`, or `finalizing` states

🤖 Generated with [Claude Code](https://claude.ai/code)